### PR TITLE
Ensure that `isMutexLocked()` works against a fresh database.

### DIFF
--- a/src/integration-test/groovy/com/budjb/mutex/DistributedMutexHelperSpec.groovy
+++ b/src/integration-test/groovy/com/budjb/mutex/DistributedMutexHelperSpec.groovy
@@ -182,4 +182,12 @@ class DistributedMutexHelperSpec extends Specification {
         then:
         notThrown LockNotAcquiredException
     }
+
+    def 'If a mutex has never been used, then a lock check should be negative'() {
+        when:
+        boolean isLocked = distributedMutexHelper.isMutexLocked(MUTEX_IDENTIFIER_NAME)
+
+        then: 'No exceptions are thrown, and the mutex is not locked'
+        !isLocked
+    }
 }

--- a/src/main/groovy/com/budjb/mutex/DistributedMutexHelper.groovy
+++ b/src/main/groovy/com/budjb/mutex/DistributedMutexHelper.groovy
@@ -47,7 +47,8 @@ class DistributedMutexHelper {
      */
     boolean isMutexLocked(String identifier) {
         DistributedMutex.withNewSession {
-            return isMutexLocked(DistributedMutex.findByIdentifier(identifier))
+            DistributedMutex dm = DistributedMutex.findByIdentifier(identifier)
+            return dm ? isMutexLocked(dm) : false
         }
     }
 


### PR DESCRIPTION
Due to changes in the version of Groovy used by Grails, when a `null` is passed to
`isMutexLocked( DistributedMutex mutex)` it can not determine which overloaded method
to call. As a result, this caused a `GroovyRuntimeException` to be thrown when on a
fresh db as the `DistributedMutex.findByIdentifier()` returns `null`.

It should also be noted that this is an issue in at least version 2.4.x of Grails. However seeing the project doesn't currently have a branch for this version of Grails, not sure how you want to proceed. (I am however currently using this in a 2.4.4 project so will need to do something on my end.)