### PR TITLE
Correct support for nested transactions.

### DIFF
--- a/src/main/groovy/com/budjb/mutex/DistributedMutexHelper.groovy
+++ b/src/main/groovy/com/budjb/mutex/DistributedMutexHelper.groovy
@@ -20,6 +20,7 @@ import org.hibernate.StaleObjectStateException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.dao.OptimisticLockingFailureException
+import org.springframework.transaction.TransactionDefinition
 
 class DistributedMutexHelper {
     /**
@@ -230,7 +231,10 @@ class DistributedMutexHelper {
         String suffix = ifNotExpired ? 'if the acquire timeout has not expired' : ''
         try {
             DistributedMutex.withNewSession {
-                DistributedMutex.withTransaction c
+                DistributedMutex.withTransaction(
+                    [propagationBehavior: TransactionDefinition.PROPAGATION_REQUIRES_NEW],
+                    c
+                )
             }
         }
         catch (OptimisticLockingFailureException ignored) {


### PR DESCRIPTION
Makes sure that the locking of the mutex occurs in another transaction so that it is not
tied to the transaction it might be called from within (say, a Service method). This change
is required due to the changes in the way `withTransaction()` work since about Grails 2.2 or 2.3.
It involves specifying the actual Spring Transaction propagation method for creating a new
transaction - whereas it used to be sufficient to just do `withSession { withTransaction { .. } }`.

Due to this change, it also means that the changes in the integration test are not rolled back at
the end of each test (as they're now in another transaction). So added `cleanup:` to all the tests
to at least free up the shared mutex. However, another option could be to ensure all entries in the
DistributedMutex directory are deleted.

In making this change I first demonstrated the issue with the provided additional test, then
resolved the issue to have the test go green.

Note: Consideration of releasing this for later 2.x versions of Grails should be given. However note I'm not sure if it will work against 2.1.x - as per above, the change was made in 2.2 or 2.3 but I can't recall which. For my initial purposes, I'll be using it on 2.4.x.